### PR TITLE
.truncate(N).toDouble() throws an error in some regions

### DIFF
--- a/src/main/kotlin/io/github/dockyardmc/ServerMetrics.kt
+++ b/src/main/kotlin/io/github/dockyardmc/ServerMetrics.kt
@@ -43,6 +43,7 @@ object ServerMetrics {
             averages.add(diff)
             timeSinceLastTick = Instant.now()
             millisecondsPerTick = Math.round(averages.average() * 10) / 10.0
+            if (millisecondsPerTick < 50) millisecondsPerTick = 50.0
         }
     }
 }

--- a/src/main/kotlin/io/github/dockyardmc/ServerMetrics.kt
+++ b/src/main/kotlin/io/github/dockyardmc/ServerMetrics.kt
@@ -2,6 +2,7 @@ package io.github.dockyardmc
 
 import io.github.dockyardmc.events.Events
 import io.github.dockyardmc.events.ServerTickEvent
+import io.github.dockyardmc.extentions.round
 import io.github.dockyardmc.periodic.Period
 import io.github.dockyardmc.periodic.SecondPeriod
 import java.time.Instant
@@ -42,7 +43,7 @@ object ServerMetrics {
             val diff = Instant.now().toEpochMilli() - timeSinceLastTick.toEpochMilli()
             averages.add(diff)
             timeSinceLastTick = Instant.now()
-            millisecondsPerTick = Math.round(averages.average() * 10) / 10.0
+            millisecondsPerTick = averages.average().round(1)
             if (millisecondsPerTick < 50) millisecondsPerTick = 50.0
         }
     }

--- a/src/main/kotlin/io/github/dockyardmc/ServerMetrics.kt
+++ b/src/main/kotlin/io/github/dockyardmc/ServerMetrics.kt
@@ -2,7 +2,6 @@ package io.github.dockyardmc
 
 import io.github.dockyardmc.events.Events
 import io.github.dockyardmc.events.ServerTickEvent
-import io.github.dockyardmc.extentions.truncate
 import io.github.dockyardmc.periodic.Period
 import io.github.dockyardmc.periodic.SecondPeriod
 import java.time.Instant
@@ -43,10 +42,7 @@ object ServerMetrics {
             val diff = Instant.now().toEpochMilli() - timeSinceLastTick.toEpochMilli()
             averages.add(diff)
             timeSinceLastTick = Instant.now()
-            millisecondsPerTick = averages.average().truncate(1).toDouble()
-            if(millisecondsPerTick < 50) millisecondsPerTick = 50.0
-
-
+            millisecondsPerTick = Math.round(averages.average() * 10) / 10.0
         }
     }
 }

--- a/src/main/kotlin/io/github/dockyardmc/extentions/ExtendedDouble.kt
+++ b/src/main/kotlin/io/github/dockyardmc/extentions/ExtendedDouble.kt
@@ -1,4 +1,8 @@
 package io.github.dockyardmc.extentions
 
-fun Double.truncate(decimals: Int): String = String.format("%.${decimals}f", this)
-fun Float.truncate(decimals: Int): String = String.format("%.${decimals}f", this)
+import java.util.*
+
+fun Double.round(decimals: Int): Double = Math.round(this * 10 * decimals) / 10.0 * decimals
+fun Double.truncate(decimals: Int): String = String.format(Locale.ROOT, "%.${decimals}f", this)
+fun Float.round(decimals: Int): Float = Math.round(this * 10 * decimals) / 10.0f * decimals
+fun Float.truncate(decimals: Int): String = String.format(Locale.ROOT, "%.${decimals}f", this)


### PR DESCRIPTION
When calculating MSPT this line throws a `NumberFormatException` in regions like Ukraine.
https://github.com/DockyardMC/Dockyard/blob/0a65f43c3be66df2104ca02ad5839a7564aa1e09/src/main/kotlin/io/github/dockyardmc/ServerMetrics.kt#L46

The issue is that in Ukraine (and in many other countries) decimal delimiter is a comma, not a period. This is what that results in:
![image](https://github.com/user-attachments/assets/c92890ea-212e-44c4-a777-973bfec28743)

I fixed this particular issue by rounding with `Math.round()`, which doesn't convert to string and doesn't have issues with localization.