### PR TITLE
Fix Profile Property not always needing to write name to ByteBuf

### DIFF
--- a/src/main/kotlin/io/github/dockyardmc/item/ItemComponentWriter.kt
+++ b/src/main/kotlin/io/github/dockyardmc/item/ItemComponentWriter.kt
@@ -184,7 +184,7 @@ fun ByteBuf.writeItemComponent(comp: ItemComponent) {
         is PlayerHeadProfileItemComponent -> {
             this.writeOptional(comp.name) { it.writeUtf(comp.name!!) }
             this.writeOptional(comp.uuid) { it.writeUUID(comp.uuid!!) }
-            this.writeProfileProperties(comp.propertyMap)
+            this.writeProfileProperties(comp.propertyMap, disableUtf = true)
         }
 
         is NoteBlockSoundItemComponent -> {

--- a/src/main/kotlin/io/github/dockyardmc/player/ProfileProperty.kt
+++ b/src/main/kotlin/io/github/dockyardmc/player/ProfileProperty.kt
@@ -7,9 +7,9 @@ import io.netty.buffer.ByteBuf
 data class ProfileProperty(val name: String, val value: String, val isSigned: Boolean, val signature: String?)
 data class ProfilePropertyMap(val name: String, val properties: MutableList<ProfileProperty>)
 
-fun ByteBuf.writeProfileProperties(propertyMap: ProfilePropertyMap) {
+fun ByteBuf.writeProfileProperties(propertyMap: ProfilePropertyMap,disableUtf: Boolean = false) {
 
-    this.writeUtf(propertyMap.name)
+    if(!disableUtf) this.writeUtf(propertyMap.name)
     this.writeVarInt(propertyMap.properties.size)
 
     propertyMap.properties.forEach {


### PR DESCRIPTION
In one place where Profile Property is used, the outgoing packet doesn't need the profile name, so I added an optional parameter (defaults to false), that disables the writing of the "name" string to the ByteBuf, fixing a bug I encountered with ItemDisplays disconnecting people when you set their item to be a PlayerHead with someone's profile info on it.