### PR TITLE
fix clipping through ceiling when flying

### DIFF
--- a/src/main/kotlin/io/github/dockyardmc/player/Player.kt
+++ b/src/main/kotlin/io/github/dockyardmc/player/Player.kt
@@ -147,7 +147,16 @@ class Player(
             equipment[EquipmentSlot.MAIN_HAND] = item
         }
 
-        isFlying.valueChanged { this.sendPacket(ClientboundPlayerAbilitiesPacket(it.newValue, isInvulnerable, canFly.value, flySpeed.value)) }
+        isFlying.valueChanged { 
+            if(it.newValue) {
+                // force standing pose if player is flying
+                this.pose.value = EntityPose.STANDING
+            } else if(this.isSneaking) {
+                this.pose.value = EntityPose.SNEAKING
+            }
+
+            this.sendPacket(ClientboundPlayerAbilitiesPacket(it.newValue, isInvulnerable, canFly.value, flySpeed.value))
+        }
         canFly.valueChanged { this.sendPacket(ClientboundPlayerAbilitiesPacket(isFlying.value, isInvulnerable, it.newValue, flySpeed.value)) }
 
         fovModifier.valueChanged { this.sendPacket(ClientboundPlayerAbilitiesPacket(isFlying.value, isInvulnerable, canFly.value, flySpeed.value, it.newValue)) }

--- a/src/main/kotlin/io/github/dockyardmc/protocol/packets/play/serverbound/ServerboundPlayerCommandPacket.kt
+++ b/src/main/kotlin/io/github/dockyardmc/protocol/packets/play/serverbound/ServerboundPlayerCommandPacket.kt
@@ -22,7 +22,12 @@ class ServerboundPlayerCommandPacket(val entityId: Int, val action: PlayerAction
             val event = when(action) {
                 PlayerAction.SNEAKING_START -> {
                     player.isSneaking = true
-                    player.pose.value = EntityPose.SNEAKING
+
+                    // the only pose that allows sneaking
+                    if(player.pose.value == EntityPose.STANDING &&
+                            !player.isFlying.value) {
+                        player.pose.value = EntityPose.SNEAKING
+                    }
 
                     player.dismountCurrentVehicle()
 
@@ -31,7 +36,11 @@ class ServerboundPlayerCommandPacket(val entityId: Int, val action: PlayerAction
                 }
                 PlayerAction.SNEAKING_STOP -> {
                     player.isSneaking = false
-                    player.pose.value = EntityPose.STANDING
+
+                    if(player.pose.value == EntityPose.SNEAKING) {
+                        player.pose.value = EntityPose.STANDING
+                    }
+
                     PlayerSneakToggleEvent(player, true)
                 }
                 PlayerAction.LEAVE_BED -> PlayerBedLeaveEvent(player)


### PR DESCRIPTION
fix #82
reason for this bug is that if you sneak (at any moment) the server *forces* you into sneaking position,
which changes your hitbox height and allows you to fly higher,
but in vanilla you cant actually fly and be in sneak *pose* at the same time, so *client* forces itself into standing position, which is inside a block, and it just clips through the ceiling

my solution is to check if player is flying before forcing them into sneaking position

also because it prevents sneaking in flight i made it so the game re-evaluates which position it should be in when you stop flying (because you can hold sneak button and land but the server will treat it as standing)
*note*: this if statement also checks if player is in standing position before sneaking, because you couldn't start sneaking if you, for example, were in swimming position and pressed sneak
but right now its pointless because the server doesn't know that you are swimming