### PR TITLE
Fix/random things

### DIFF
--- a/src/main/kotlin/io/github/dockyardmc/entity/Entity.kt
+++ b/src/main/kotlin/io/github/dockyardmc/entity/Entity.kt
@@ -393,6 +393,7 @@ abstract class Entity(open var location: Location, open var world: World) : Disp
         equipmentLayers.clear()
         viewers.toList().forEach { removeViewer(it) }
         metadataLayers.clear()
+        passengers.values.forEach(passengers::removeIfPresent)
         bindablePool.dispose()
         EntityManager.despawnEntity(this)
     }

--- a/src/main/kotlin/io/github/dockyardmc/player/systems/EntityViewSystem.kt
+++ b/src/main/kotlin/io/github/dockyardmc/player/systems/EntityViewSystem.kt
@@ -27,7 +27,7 @@ class EntityViewSystem(val player: Player): TickablePlayerSystem {
         val add = entities.filter { it.location.distance(player.location) <= it.viewDistanceBlocks && !visibleEntities.contains(it) }
         val remove = entities.filter { it.location.distance(player.location) > it.viewDistanceBlocks && visibleEntities.contains(it) }
 
-        add.forEach { entity -> entity.addViewer(player); visibleEntities.addIfNotPresent(entity) }
-        remove.forEach { entity -> entity.removeViewer(player); visibleEntities.removeIfPresent(entity) }
+        add.forEach { entity -> entity.addViewer(player) }
+        remove.forEach { entity -> entity.removeViewer(player) }
     }
 }

--- a/src/main/kotlin/io/github/dockyardmc/protocol/packets/play/serverbound/ServerboundPlayerCommandPacket.kt
+++ b/src/main/kotlin/io/github/dockyardmc/protocol/packets/play/serverbound/ServerboundPlayerCommandPacket.kt
@@ -14,43 +14,52 @@ import io.netty.channel.ChannelHandlerContext
 // Note: Do not confuse with io.github.dockyardmc.commands packets, this is packet that
 // describes actions of player (if they are sneaking, sprinting etc.)
 // idk why they named it "player command" packet, im just following the standard
-class ServerboundPlayerCommandPacket(val entityId: Int, val action: PlayerAction): ServerboundPacket {
+class ServerboundPlayerCommandPacket(val entityId: Int, val action: PlayerAction) : ServerboundPacket {
 
     override fun handle(processor: PlayerNetworkManager, connection: ChannelHandlerContext, size: Int, id: Int) {
         val player = processor.player
 
-            val event = when(action) {
-                PlayerAction.SNEAKING_START -> {
-                    player.isSneaking = true
+        val event = when (action) {
+            PlayerAction.SNEAKING_START -> {
+                player.isSneaking = true
 
-                    // the only pose that allows sneaking
-                    if(player.pose.value == EntityPose.STANDING &&
-                            !player.isFlying.value) {
-                        player.pose.value = EntityPose.SNEAKING
-                    }
-
-                    player.dismountCurrentVehicle()
-
-                    PlayerSneakToggleEvent(player, true)
-
+                // the only pose that allows sneaking
+                if (player.pose.value == EntityPose.STANDING &&
+                    !player.isFlying.value
+                ) {
+                    player.pose.value = EntityPose.SNEAKING
                 }
-                PlayerAction.SNEAKING_STOP -> {
-                    player.isSneaking = false
 
-                    if(player.pose.value == EntityPose.SNEAKING) {
-                        player.pose.value = EntityPose.STANDING
-                    }
+                player.dismountCurrentVehicle()
 
-                    PlayerSneakToggleEvent(player, true)
-                }
-                PlayerAction.LEAVE_BED -> PlayerBedLeaveEvent(player)
-                PlayerAction.SPRINTING_START -> { player.isSprinting = true; PlayerSprintToggleEvent(player, true) }
-                PlayerAction.SPRINTING_END -> { player.isSprinting = false; PlayerSprintToggleEvent(player, false) }
-                PlayerAction.HORSE_JUMP_START -> HorseJumpEvent(player, true)
-                PlayerAction.HORSE_JUMP_END -> HorseJumpEvent(player, true)
-                PlayerAction.VEHICLE_INVENTORY_OPEN -> PlayerVehicleInventoryOpenEvent(player)
-                PlayerAction.ELYTRA_FLYING_START -> PlayerElytraFlyingStartEvent(player)
+                PlayerSneakToggleEvent(player, true)
+
             }
+
+            PlayerAction.SNEAKING_STOP -> {
+                player.isSneaking = false
+
+                if (player.pose.value == EntityPose.SNEAKING) {
+                    player.pose.value = EntityPose.STANDING
+                }
+
+                PlayerSneakToggleEvent(player, true)
+            }
+
+            PlayerAction.LEAVE_BED -> PlayerBedLeaveEvent(player)
+            PlayerAction.SPRINTING_START -> {
+                player.isSprinting = true; PlayerSprintToggleEvent(player, true)
+            }
+
+            PlayerAction.SPRINTING_END -> {
+                player.isSprinting = false; PlayerSprintToggleEvent(player, false)
+            }
+
+            PlayerAction.HORSE_JUMP_START -> HorseJumpEvent(player, true)
+            PlayerAction.HORSE_JUMP_END -> HorseJumpEvent(player, true)
+            PlayerAction.VEHICLE_INVENTORY_OPEN -> PlayerVehicleInventoryOpenEvent(player)
+            PlayerAction.ELYTRA_FLYING_START -> PlayerElytraFlyingStartEvent(player)
+        }
 
         Events.dispatch(event)
     }

--- a/src/main/kotlin/io/github/dockyardmc/protocol/packets/play/serverbound/ServerboundPlayerCommandPacket.kt
+++ b/src/main/kotlin/io/github/dockyardmc/protocol/packets/play/serverbound/ServerboundPlayerCommandPacket.kt
@@ -17,7 +17,7 @@ import io.netty.channel.ChannelHandlerContext
 class ServerboundPlayerCommandPacket(val entityId: Int, val action: PlayerAction): ServerboundPacket {
 
     override fun handle(processor: PlayerNetworkManager, connection: ChannelHandlerContext, size: Int, id: Int) {
-        val player = PlayerManager.playerToEntityIdMap[entityId] ?: return
+        val player = processor.player
 
             val event = when(action) {
                 PlayerAction.SNEAKING_START -> {

--- a/src/main/kotlin/io/github/dockyardmc/world/World.kt
+++ b/src/main/kotlin/io/github/dockyardmc/world/World.kt
@@ -101,8 +101,8 @@ class World(var name: String, var generator: WorldGenerator, var dimensionType: 
         if (event.cancelled) return
 
         // tick entities
-        synchronized(entities) {
-            scheduler.run {
+        scheduler.run {
+            synchronized(innerEntities) {
                 entities.forEach {
                     if (it.tickable) it.tick()
                 }


### PR DESCRIPTION
- fix: EntityViewSystem.tick() can sometimes add entity twice, or adds it even if event is canceled
  you forgor
- fix(Entity): remove all passengers when disposed
- fix(World): fix synchronize for ticking entities
- fix: ignore entity id and just use current packet player (i blindly believe the [wiki](https://minecraft.wiki/w/Java_Edition_protocol#:~:text=(ignored%20by%20the%20vanilla%20server)))