### PR TITLE
fix bossbar being visible after disposing

### DIFF
--- a/src/main/kotlin/io/github/dockyardmc/apis/bossbar/Bossbar.kt
+++ b/src/main/kotlin/io/github/dockyardmc/apis/bossbar/Bossbar.kt
@@ -44,7 +44,7 @@ class Bossbar(
 
     override fun dispose() {
         eventPool.dispose()
-        viewers.toList().forEach(viewers::remove)
+        viewers.toList().forEach(::removeViewer)
     }
 
     override fun addViewer(player: Player) {


### PR DESCRIPTION
instead of removing from the list run the removeViewer function
