### PR TITLE
fix: reset style after server brand

### DIFF
--- a/src/main/kotlin/io/github/dockyardmc/protocol/packets/configurations/ConfigurationHandler.kt
+++ b/src/main/kotlin/io/github/dockyardmc/protocol/packets/configurations/ConfigurationHandler.kt
@@ -45,7 +45,7 @@ class ConfigurationHandler(val processor: PlayerNetworkManager) : PacketHandler(
             val networkManager = player.networkManager
 
             // Send server brand
-            val serverBrandEvent = ServerBrandEvent("§3DockyardMC ${DockyardServer.versionInfo.getFormatted(DockyardServer.minecraftVersion)}")
+            val serverBrandEvent = ServerBrandEvent("§3DockyardMC ${DockyardServer.versionInfo.getFormatted(DockyardServer.minecraftVersion)}§r")
             Events.dispatch(serverBrandEvent)
             connection.sendPacket(BrandPluginMessage(serverBrandEvent.brand).asConfigPacket("minecraft:brand"), networkManager)
 


### PR DESCRIPTION
idk if its intentional but
the text color after brand is not reset
so brand line is cyan all the way in f3
